### PR TITLE
Bugfix: Removed image get request as it is creating 404 error

### DIFF
--- a/stylesheets/system.menus.css
+++ b/stylesheets/system.menus.css
@@ -24,7 +24,7 @@ ul li.collapsed {
   list-style-type: disc;
 }
 ul li.leaf {
-  list-style-image: url(../../misc/menu-leaf.png);
+  list-style-image: url();
   list-style-type: square;
 }
 li.expanded,


### PR DESCRIPTION
Removed image (menu-leaf.png) get request as it is creating 404 error in console.

![404](https://cloud.githubusercontent.com/assets/4817493/6542449/64bd391c-c51e-11e4-9454-1ff4d4938f8d.png)
