### PR TITLE
Fixed height of gray events dropdown menu

### DIFF
--- a/ideas.html
+++ b/ideas.html
@@ -77,7 +77,7 @@
 									<li><a target="_self" href="http://fossasia.org/#subscribe">Subscribe</a></li>										
 									<li><a href="http://blog.fossasia.org" target="_self">Blog</a></li>
 									<li class="has-dropdown"><a href="http://events.fossasia.org">Events</a>
-										<ul class="nav-dropdown">
+										<ul class="nav-dropdown" style="min-height:425px"> <!--whenever you add/remove an option, change the style="min-height:425px" by +- 25px-->
 											<li><a target="_self" href="http://events.fossasia.org/#sponsorship">Sponsorship</a></li>
 											<li><a target="_self" href="http://eventyay.com">FOSSASIA Event Management</a></li>
 											<li><a href="http://sciencehack.asia" target="_self">Science Hack Asia</a></li>

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
 									<li><a target="_self" href="http://fossasia.org/#subscribe">Subscribe</a></li>
 									<li><a href="http://blog.fossasia.org" target="_self">blog</a></li>
 									<li class="has-dropdown"><a href="http://events.fossasia.org">Events</a>
-										<ul class="nav-dropdown">
+										<ul class="nav-dropdown" style="min-height:425px"> <!--whenever you add/remove an option, change the style="min-height:425px" by +- 25px-->
 											<li><a target="_self" href="http://events.fossasia.org/#sponsorship">Sponsorship</a></li>
 											<li><a target="_self" href="http://eventyay.com">FOSSASIA Event Management</a></li>
 											<li><a href="http://sciencehack.asia" target="_self">Science Hack Asia</a></li>

--- a/stipends.html
+++ b/stipends.html
@@ -77,7 +77,7 @@
 									<li><a target="_self" href="http://fossasia.org/#subscribe">Subscribe</a></li>										
 									<li><a href="http://blog.fossasia.org" target="_self">Blog</a></li>
 									<li class="has-dropdown"><a href="http://events.fossasia.org">Events</a>
-										<ul class="nav-dropdown">
+										<ul class="nav-dropdown" style="min-height:425px"> <!--whenever you add/remove an option, change the style="min-height:425px" by +- 25px-->
 											<li><a target="_self" href="http://events.fossasia.org/#sponsorship">Sponsorship</a></li>
 											<li><a target="_self" href="http://eventyay.com">FOSSASIA Event Management</a></li>
 											<li><a href="http://sciencehack.asia" target="_self">Science Hack Asia</a></li>


### PR DESCRIPTION
1.Fixed the height of dropdown menu by using inline styling, style="min-
height:425px"
2.Made this change to three files i.e. index.html, ideas.html, stipends.html
3.Also, added comments to help with further addition/deletion of entries in the dropdown menu.

Before, index.html:
![rsz_labs](https://cloud.githubusercontent.com/assets/14184381/18729497/a47d0754-806f-11e6-8013-1e46d85dba5e.png)

After, index.html:
![rsz_labsfossasia](https://cloud.githubusercontent.com/assets/14184381/18729511/b34e880c-806f-11e6-86fe-20aa324c244e.png)

Before, ideas.html:
![rsz_labsideas1](https://cloud.githubusercontent.com/assets/14184381/18729559/e5d6415c-806f-11e6-9666-4bdbc238f5d1.png)

After, ideas.html:
![rsz_labsideas](https://cloud.githubusercontent.com/assets/14184381/18729594/0d3a4428-8070-11e6-8c8b-8c954bea20d4.png)

Before, stipends.html:
![rsz_stipend1](https://cloud.githubusercontent.com/assets/14184381/18729648/37b9e10e-8070-11e6-9957-de5492d8d6cf.png)

After, stipends.html:
![rsz_stipend_after](https://cloud.githubusercontent.com/assets/14184381/18729691/5eab034c-8070-11e6-823c-d5a41f664f17.png)

