### PR TITLE
aligned github link closes #168

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,7 +322,10 @@
 								<div class="info-box">
 									<img alt="Venue" src="img/16685244587_dc6defba93_z.jpg">
 									<h3>Software Projects</h3>
-									<p>We develop many Open Source software projects from Wordpress plugins to knitting machine projects or event management solutions. Please join us in creating useful tools that make the world a better place.</p><div><br></div>	<div class="text-link">
+									<p>We develop many Open Source software projects from Wordpress plugins to knitting machine projects or event management solutions. Please join us in creating useful tools that make the world a better place.<br><br><br><br><br></p>
+									
+
+										<div class="text-link">
 										
 										<a href="https://github.com/fossasia" target="default">FOSSASIA Github Repo</a>
 									</div>			


### PR DESCRIPTION
Fixed the alignment. Looks like this: 

![selection_007](https://cloud.githubusercontent.com/assets/8419333/20247304/e7810516-a9ee-11e6-9ed2-ec1e053faafe.png)

This closes https://github.com/fossasia/labs.fossasia.org/issues/168