### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/fossasia/labs.fossasia.org.svg?branch=gh-pages)](https://travis-ci.org/fossasia/labs.fossasia.org)
 
-##labs.fossasia.org
+## labs.fossasia.org
 
 Code of website: http://labs.fossasia.org


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
