### PR TITLE
Fixed downward movement of links

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -78,7 +78,6 @@
 .sticky-nav .menu li a:hover {
   border-color: #C3BFBF;
   border-bottom-width: 2px;
-  margin-top: 4px;
   margin-bottom: 2px;
 }
 


### PR DESCRIPTION
* Fixed Downward movement of Nav links when they are hovered on.
* Fixes #232 .

**Please Note :** The downward movement occurs only when you are not at the top of the page. (the `.sticky-nav` class is added to the nav).

**Here is the live link :** https://duttaditya18.github.io/labs.fossasia.org/

Please take a look @mariobehling , @fossasia/website-admins, @fossasia/web-developers.

If you do not see some images, it would be because your browser / adblock could be blocking them for being "mixed content". The images would be fine on the actual website.