### PR TITLE
Fix minor typographical error in github link

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,7 +530,7 @@
 								At FOSSASIA we develop a number of social search plugins and widgets for Wordpress.<br>
 								[Technologies used: PHP, MySQL/MariaDB, Javascript, HTML, CSS, JSON]<br><a href="https://fossasia.slack.com/messages/developers/" target="_self">Chat: fossasia.slack.com/messages/developers/</a><br><a href="http://fossasia-slack.herokuapp.com/" target="_self">[Get a Slack Invite]</a><br>
 								<a href="https://groups.google.com/group/fossasia" target="_self">Mailing List: groups.google.com/group/fossasia/</a><br>
-								<a href="https://github.com/fossasia?utf8=✓&q=wp" target="_self">Contribute: ithub.com/fossasia?utf8=✓&q=wp</a>
+								<a href="https://github.com/fossasia?utf8=✓&q=wp" target="_self">Contribute: github.com/fossasia?utf8=✓&q=wp</a>
 							</p>
 						</div>
 					</div>


### PR DESCRIPTION
For the Wordpress Plugins section, under the Contribute link, a missing 'g'

![image](https://user-images.githubusercontent.com/859780/37391073-14e7d0cc-27a5-11e8-8148-290b99221902.png)
