### PR TITLE
Fixed Logo Padding, Rearranged Project

### DIFF
--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -459,7 +459,6 @@ nav .logo {
   max-height: 45px;
   max-width: 110px;
   position: absolute;
-  top: -6px;
   opacity: 1;
 }
 nav .text-right {
@@ -849,7 +848,7 @@ nav .container {
   .nav-dropdown {
     position: relative;
     display: none;
-    min-height: 439px; 
+    min-height: 439px;
  }
   .has-dropdown:hover .nav-dropdown {
     display: block;

--- a/index.html
+++ b/index.html
@@ -781,41 +781,6 @@
 
 			</section>
 
-<a id="labyrinth" class="in-page-link"></a>
-
-			<section class="image-with-text testimonials preserve-3d">
-
-				<div class="go-left side-image col-sm-4 col-md-6">
-					<div class="background-image-holder">
-						<img class="background-image" alt="labyrinth" src="img/labyrinth.png">
-					</div>
-				</div>
-
-				<div class="container vertical-align">
-					<div class="row">
-						<div class="col-md-offset-7 col-sm-7 col-sm-offset-5 col-md-5">
-							<div class="testimonials-slider">
-								<ul class="slides">
-									<li>
-										<h1>Labyrinth</h1>
-										<p class="lead">
-											Labyrinth is a exciting game full of mazes. Too many Levels, Too much fun! Come, and Develop Labyrinth game.<br>[Technologies used: Javascript, HTML, CSS]
-
-                      <div class="project-links">
-                          <a href="http://rawgit.com/fossasia/labyrinth/master/index.html" target="_self"  title="Website" class="fa fa-link"></a>
-                          <a href="https://gitter.im/fossasia/labyrinth" target="_self" title="Chat Channel" class="fa fa-comments"></a>
-                          <a href="https://github.com/fossasia/labyrinth" target="_self" title="Contribute" class="fa fa-github"></a>
-                      </div>
-
-										</p>
-									</li>
-								</ul>
-							</div>
-						</div>
-					</div>
-				</div>
-			</section>
-
 			<a id="linux" class="in-page-link"></a>
 
 			<section class="image-with-text background-dark preserve-3d">
@@ -988,6 +953,41 @@
 				</div>
 
 			</section>
+
+      <a id="labyrinth" class="in-page-link"></a>
+
+      			<section class="image-with-text testimonials preserve-3d">
+
+      				<div class="go-left side-image col-sm-4 col-md-6">
+      					<div class="background-image-holder">
+      						<img class="background-image" alt="labyrinth" src="img/labyrinth.png">
+      					</div>
+      				</div>
+
+      				<div class="container vertical-align">
+      					<div class="row">
+      						<div class="col-md-offset-7 col-sm-7 col-sm-offset-5 col-md-5">
+      							<div class="testimonials-slider">
+      								<ul class="slides">
+      									<li>
+      										<h1>Labyrinth</h1>
+      										<p class="lead">
+      											Labyrinth is a exciting game full of mazes. Too many Levels, Too much fun! Come, and Develop Labyrinth game.<br>[Technologies used: Javascript, HTML, CSS]
+
+                            <div class="project-links">
+                                <a href="http://rawgit.com/fossasia/labyrinth/master/index.html" target="_self"  title="Website" class="fa fa-link"></a>
+                                <a href="https://gitter.im/fossasia/labyrinth" target="_self" title="Chat Channel" class="fa fa-comments"></a>
+                                <a href="https://github.com/fossasia/labyrinth" target="_self" title="Contribute" class="fa fa-github"></a>
+                            </div>
+
+      										</p>
+      									</li>
+      								</ul>
+      							</div>
+      						</div>
+      					</div>
+      				</div>
+      			</section>
 
 
 			<a id="join" class="in-page-link"></a>


### PR DESCRIPTION
**Fix 1: Positioning of FOSSASIA Logo in Top-bar fixed**
I have fixed the padding issue with the FOSSASIA logo. The logo was earlier placed slightly above the normal positioning of the navbar. (applied to current theme-lava.css only)
![image](https://user-images.githubusercontent.com/21276922/47652456-00424100-dbac-11e8-9425-574630256b71.png)

**Fix 2: Rearranged Labyrinth project to match alternate alignment**
The project cards of Flappy SVG game and Labyrinth were both aligned to the same direction, while it is the general ui where the projects are alternatively aligned left and right. I moved the labyrinth project below Badgeyay, and now all projects are aligned alternatively left and right.

Before rearranging
![image](https://user-images.githubusercontent.com/21276922/47652740-bad24380-dbac-11e8-8d81-9361c0e923c8.png)

After rearranging
![image](https://user-images.githubusercontent.com/21276922/47652774-d9383f00-dbac-11e8-8c61-bf2726106d36.png)

Live Preview of the changes available at https://aswinshenoy.com/labs.fossasia.org/