### PR TITLE
Aligned Links in Projects Sections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - gem install github-pages --no-rdoc --no-ri
 
 rvm:
-- 2.1
+- 2.3
 script: jekyll build
 
 branches:

--- a/css/custom.css
+++ b/css/custom.css
@@ -139,7 +139,7 @@ div.copy-text {
 .link-bottom-left
 {
   position: absolute;
-  bottom: -3%;
+  bottom: 1%;
   left: 0;
   vertical-align: top;
   margin-bottom: 7%;
@@ -152,4 +152,14 @@ div.copy-text {
   right: 5%;
   vertical-align: top;
   margin-bottom: 7%;
+}
+
+.info-box
+{
+  margin-bottom: 2%;
+}
+
+.faq-item
+{
+  margin-bottom: 17%;
 }

--- a/css/custom.css
+++ b/css/custom.css
@@ -128,3 +128,28 @@ div.copy-text {
     background: #e12b00;
     border-color: #e12b00;
 }
+
+.row-equal
+{
+  display: flex;
+  display: -webkit-flex;
+  flex-wrap: wrap;
+}
+
+.link-bottom-left
+{
+  position: absolute;
+  bottom: -3%;
+  left: 0;
+  vertical-align: top;
+  margin-bottom: 7%;
+}
+
+.link-bottom-right
+{
+  position: absolute;
+  bottom: -3%;
+  right: 5%;
+  vertical-align: top;
+  margin-bottom: 7%;
+}

--- a/index.html
+++ b/index.html
@@ -314,17 +314,16 @@
 							</div>
 						</div>
 
-						<div class="row">
+						<div class="row row-equal">
 							<div class="col-md-4 col-sm-6">
 								<div class="info-box">
 									<img alt="Venue" src="img/16704948658_0dff7bd62c_z.jpg">
 									<h3>Science Hack Lab<br></h3>
-									<p>
-										In the FOSSASIA Pocket Science Lab project we develop hardware for schools and universities to enable hands-on learning for about physics and chemistry. We also organize Science Hack Days across Asia and cooperate with universities and numerous local partners and companies.<br><br><br></p>
-									<div class="text-link">
-
-										<a href="http://sciencehack.asia" target="_self">sciencehack.asia</a>
-									</div>
+									<p>In the FOSSASIA Pocket Science Lab project we develop hardware for schools and universities to enable hands-on learning for about physics and chemistry. We also organize Science Hack Days across Asia and cooperate with universities and numerous local partners and companies.</p>
+									<br>
+								</div>
+								<div class="text-link link-bottom-right">
+									<a href="http://sciencehack.asia" target="_self">sciencehack.asia</a>
 								</div>
 							</div>
 
@@ -332,10 +331,11 @@
 								<div class="info-box">
 									<img alt="Venue" src="img/16685244587_dc6defba93_z.jpg">
 									<h3>Software Projects</h3>
-									<p>We develop many Open Source software projects from Wordpress plugins to knitting machine projects or event management solutions. Please join us in creating useful tools that make the world a better place.<br><br><br><br></p>
-										<div class="text-link">
-										<a href="https://github.com/fossasia" target="default">FOSSASIA Github Repo</a>
-									</div>
+									<p>We develop many Open Source software projects from Wordpress plugins to knitting machine projects or event management solutions. Please join us in creating useful tools that make the world a better place.</p>
+									<br>
+								</div>
+								<div class="text-link link-bottom-right">
+									<a href="https://github.com/fossasia" target="default">FOSSASIA Github Repo</a>
 								</div>
 							</div>
 							<div class="col-md-4 col-sm-6">
@@ -999,27 +999,33 @@
 							<h1>How Can I Join Projects</h1>
 						</div>
 					</div>
-					<div class="row">
+					<div class="row row-equal">
 						<div class="col-sm-4 col-md-4">
 							<div class="faq-item">
 								<p class="question">Join the FOSSASIA Developers Mailing List</p>
-
-								<p>
-								FOSSASIA developers are active on a number of dedicated mailing lists to discuss questions. The FOSSASIA developer mailing list is a place to share information across projects. Please help us to spread information and share your ideas. Let's start the conversation and working together!<br><br><a href="https://groups.google.com/forum/#!forum/fossasia" class="inner-link" target="_self">Subscribe to the FOSSASIA Developers Mailing List</a>&nbsp; &nbsp; &nbsp;&nbsp;</p>
+								<p>FOSSASIA developers are active on a number of dedicated mailing lists to discuss questions. The FOSSASIA developer mailing list is a place to share information across projects. Please help us to spread information and share your ideas. Let's start the conversation and working together!</p>
+								<br>
+							</div>
+							<div class="text-link link-bottom-left">
+								<a href="https://groups.google.com/forum/#!forum/fossasia" target="_self">Subscribe to the FOSSASIA Developers Mailing List</a>
 							</div>
 						</div><div class="col-sm-4 col-md-4">
 							<div class="faq-item">
 								<p class="question">Become a contributor and solve a bug, implement a new feature or write a unit test. </p>
-
-								<p>
-								We are looking for your expertise, be it as a software developer, hardware maker, designer or administrator. Please join us and contribute to our projects on Github. Solving a bug, implementing a new feature, writing unit tests and giving feedback on existing projects is the first step before joining FOSSASIA coding programs.<br><br><a href="#projects" class="inner-link" target="_self">See an overview of current main projects</a></p>
+								<p>We are looking for your expertise, be it as a software developer, hardware maker, designer or administrator. Please join us and contribute to our projects on Github. Solving a bug, implementing a new feature, writing unit tests and giving feedback on existing projects is the first step before joining FOSSASIA coding programs.</p>
+								<br>
+							</div>
+							<div class="text-link link-bottom-left">
+								<a href="#projects" class="inner-link" target="_self">See an overview of current main projects</a>
 							</div>
 						</div><div class="col-sm-4 col-md-4">
 							<div class="faq-item">
 								<p class="question">Join an OpenTech event or organize your own. </p>
-								<p>
-								FOSSASIA groups and projects exist throughout Asia. Still there are many white spots left, where you can help to spread free knowledge and Open Technology tools. Why not put together a FOSSASIA developers event and and meet like-minded contributors to talk about coding projects? Organize an event with our Open Source event tool eventyay.com and share it on social media channels - tweet it @fossasia.<br><br><a href="http://eventyay.com" target="_self">Join OpenTech events or organize your own with eventyay.com</a>
-								</p>
+								<p>FOSSASIA groups and projects exist throughout Asia. Still there are many white spots left, where you can help to spread free knowledge and Open Technology tools. Why not put together a FOSSASIA developers event and and meet like-minded contributors to talk about coding projects? Organize an event with our Open Source event tool eventyay.com and share it on social media channels - tweet it @fossasia.</p>
+								<br>
+							</div>
+							<div class="text-link link-bottom-left">
+								<a href="http://eventyay.com" target="_self">Join OpenTech events or organize your own with eventyay.com</a>
 							</div>
 						</div>
 


### PR DESCRIPTION
Fixes #299 

Aligned the links in the Fossasia Projects and How Can I Join projects Section.

![screen shot 2018-11-01 at 5 39 21 pm](https://user-images.githubusercontent.com/8119928/47881685-388c8e00-ddfd-11e8-8115-61270153c970.png)
![screen shot 2018-11-01 at 5 39 31 pm](https://user-images.githubusercontent.com/8119928/47881687-3aeee800-ddfd-11e8-814a-d9245a67a486.png)
![screen shot 2018-11-01 at 5 40 00 pm](https://user-images.githubusercontent.com/8119928/47881689-3de9d880-ddfd-11e8-8952-efd93e580a1d.png)
![screen shot 2018-11-01 at 5 40 07 pm](https://user-images.githubusercontent.com/8119928/47881693-404c3280-ddfd-11e8-9693-f3eeea815c7d.png)


Testing Link: https://ryan10145.github.io/labs.fossasia.org/