### PR TITLE
Update Instagram icon in the footer

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -21,7 +21,8 @@
         <link rel="shortcut icon" href="fossasia.ico" type="image/x-icon" />
         <link href="css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/flexslider.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/elegant-icons.min.css" rel="stylesheet" type="text/css" media="all"/>
+		<link href="css/elegant-icons.min.css" rel="stylesheet" type="text/css" media="all"/>
+		<link href="css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/pe-icon-7-stroke.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/lightbox.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/theme-lava.css" rel="stylesheet" type="text/css" media="all"/>
@@ -214,7 +215,7 @@
 								<li><a target="default" href="http://facebook.com/fossasia"><i class="icon social_facebook"></i></a></li>
 								<li><a target="default" href="https://www.linkedin.com/groups/FOSSASIA-3762811"><i class="icon social_linkedin icon-large"></i></a></li>
 								<li><a target="default" href="https://www.youtube.com/channel/UCQprMsG-raCIMlBudm20iLQ"><i class="icon social_youtube icon-large"></i></a></li>
-								<li><a target="default" href="https://www.flickr.com/photos/fossasia"><i class="icon social_instagram icon-large"></i></a></li>
+								<li><a target="default" href="https://www.flickr.com/photos/fossasia"><i class="fa fa-instagram fa-lg"></i></a></li>
 							</ul>	
 						</div>
 					</div>

--- a/archive.html
+++ b/archive.html
@@ -20,9 +20,9 @@
 
         <link rel="shortcut icon" href="fossasia.ico" type="image/x-icon" />
         <link href="css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/flexslider.min.css" rel="stylesheet" type="text/css" media="all"/>
-		<link href="css/elegant-icons.min.css" rel="stylesheet" type="text/css" media="all"/>
-		<link href="css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all"/>
+		<link href="css/flexslider.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="css/elegant-icons.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/pe-icon-7-stroke.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/lightbox.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/theme-lava.css" rel="stylesheet" type="text/css" media="all"/>
@@ -215,7 +215,7 @@
 								<li><a target="default" href="http://facebook.com/fossasia"><i class="icon social_facebook"></i></a></li>
 								<li><a target="default" href="https://www.linkedin.com/groups/FOSSASIA-3762811"><i class="icon social_linkedin icon-large"></i></a></li>
 								<li><a target="default" href="https://www.youtube.com/channel/UCQprMsG-raCIMlBudm20iLQ"><i class="icon social_youtube icon-large"></i></a></li>
-								<li><a target="default" href="https://www.flickr.com/photos/fossasia"><i class="fa fa-instagram fa-lg"></i></a></li>
+								<li><a target="default" href="https://www.flickr.com/photos/fossasia"><i class="fa fa-flickr fa-lg"></i></a></li>
 							</ul>	
 						</div>
 					</div>

--- a/archive.html
+++ b/archive.html
@@ -20,7 +20,7 @@
 
         <link rel="shortcut icon" href="fossasia.ico" type="image/x-icon" />
         <link href="css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
-		<link href="css/flexslider.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="css/flexslider.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/elegant-icons.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="css/pe-icon-7-stroke.min.css" rel="stylesheet" type="text/css" media="all"/>

--- a/index.html
+++ b/index.html
@@ -587,7 +587,7 @@
 								<li><a target="_self" href="https://www.linkedin.com/groups/FOSSASIA-3762811"><i class="icon social_linkedin icon-large"></i></a></li>
 								<li><a target="_self" href="https://www.youtube.com/channel/UCQprMsG-raCIMlBudm20iLQ"><i class="icon social_youtube icon-large"></i></a></li>
 								<li><a target="_self" href="https://www.flickr.com/photos/fossasia"><i class="icon social_flickr icon-large"></i></a></li>
-                				<li><a target="_self" href="https://www.instagram.com/explore/tags/fossasia/"><i class="fa fa-instagram fa-lg"></i></a></li>
+								<li><a target="_self" href="https://www.instagram.com/explore/tags/fossasia/"><i class="fa fa-instagram fa-lg"></i></a></li>
 								<li><a target="_self" href="https://github.com/fossasia"><i class="fa fa-github fa-lg"></i></a></li>
 								<li><a target="_self" href="https://gitlab.com/fossasia"><i class="fa fa-gitlab fa-lg"></i></a></li>
 								<li><a target="_self" href="https://www.weibo.com/u/5784920339"><i class="fa fa-weibo fa-lg"></i></a></li>

--- a/index.html
+++ b/index.html
@@ -587,7 +587,7 @@
 								<li><a target="_self" href="https://www.linkedin.com/groups/FOSSASIA-3762811"><i class="icon social_linkedin icon-large"></i></a></li>
 								<li><a target="_self" href="https://www.youtube.com/channel/UCQprMsG-raCIMlBudm20iLQ"><i class="icon social_youtube icon-large"></i></a></li>
 								<li><a target="_self" href="https://www.flickr.com/photos/fossasia"><i class="icon social_flickr icon-large"></i></a></li>
-                				<li><a target="_self" href="https://www.instagram.com/explore/tags/fossasia/"><i class="icon social_instagram"></i></a></li>
+                				<li><a target="_self" href="https://www.instagram.com/explore/tags/fossasia/"><i class="fa fa-instagram fa-lg"></i></a></li>
 								<li><a target="_self" href="https://github.com/fossasia"><i class="fa fa-github fa-lg"></i></a></li>
 								<li><a target="_self" href="https://gitlab.com/fossasia"><i class="fa fa-gitlab fa-lg"></i></a></li>
 								<li><a target="_self" href="https://www.weibo.com/u/5784920339"><i class="fa fa-weibo fa-lg"></i></a></li>

--- a/projects.html
+++ b/projects.html
@@ -1286,7 +1286,7 @@
 								<li><a title="linkedin" target="_self" href="https://www.linkedin.com/groups/FOSSASIA-3762811"><i class="icon social_linkedin icon-large"></i></a></li>
 								<li><a title="youtube" target="_self" href="https://www.youtube.com/channel/UCQprMsG-raCIMlBudm20iLQ"><i class="icon social_youtube icon-large"></i></a></li>
 								<li><a title="flickr" target="_self" href="https://www.flickr.com/photos/fossasia"><i class="icon social_flickr icon-large"></i></a></li>
-                                <li><a title="instagram" target="_self" href="https://www.instagram.com/explore/tags/fossasia/"><i class="icon social_instagram"></i></a></li>
+                                <li><a title="instagram" target="_self" href="https://www.instagram.com/explore/tags/fossasia/"><i class="fa fa-instagram fa-lg"></i></a></li>
 								<li><a title="github" target="_self" href="https://github.com/fossasia"><i class="fa fa-github fa-lg"></i></a></li>
 								<li><a title="fossasia" target="_self" href="https://www.fossasia.net"><i class="icon social_dribbble"></i></a></li>
 								<li><a title="vk" target="_self" href="https://www.vk.com/fossasia"><i class="fa fa-vk"></i></a></li>

--- a/projects.html
+++ b/projects.html
@@ -1286,7 +1286,7 @@
 								<li><a title="linkedin" target="_self" href="https://www.linkedin.com/groups/FOSSASIA-3762811"><i class="icon social_linkedin icon-large"></i></a></li>
 								<li><a title="youtube" target="_self" href="https://www.youtube.com/channel/UCQprMsG-raCIMlBudm20iLQ"><i class="icon social_youtube icon-large"></i></a></li>
 								<li><a title="flickr" target="_self" href="https://www.flickr.com/photos/fossasia"><i class="icon social_flickr icon-large"></i></a></li>
-                                <li><a title="instagram" target="_self" href="https://www.instagram.com/explore/tags/fossasia/"><i class="fa fa-instagram fa-lg"></i></a></li>
+								<li><a title="instagram" target="_self" href="https://www.instagram.com/explore/tags/fossasia/"><i class="fa fa-instagram fa-lg"></i></a></li>
 								<li><a title="github" target="_self" href="https://github.com/fossasia"><i class="fa fa-github fa-lg"></i></a></li>
 								<li><a title="fossasia" target="_self" href="https://www.fossasia.net"><i class="icon social_dribbble"></i></a></li>
 								<li><a title="vk" target="_self" href="https://www.vk.com/fossasia"><i class="fa fa-vk"></i></a></li>


### PR DESCRIPTION
Fixes #427 
This updates the Instagram icon by switching the icon font from Elegant Icons to Font Awesome.
Also in archive.html I changed the Instagram icon to Flickr icon because the link goes to Flickr

Before:
![image](https://user-images.githubusercontent.com/28688352/72896471-23608f80-3d20-11ea-9190-992156e33d5e.png)

After:
![image](https://user-images.githubusercontent.com/28688352/72896491-2a879d80-3d20-11ea-9ecf-a900f889ec5f.png)